### PR TITLE
Fix TLS startup after #!/usr/bin/env sh change

### DIFF
--- a/startup-nginx.sh
+++ b/startup-nginx.sh
@@ -18,11 +18,11 @@ rm /var/www/rutorrent/.htpasswd
 site=rutorrent-basic.nginx
 
 # Check if TLS needed
-if [[ -e /downloads/nginx.key && -e /downloads/nginx.crt ]]; then
-mkdir -p /etc/nginx/ssl
-cp /downloads/nginx.crt /etc/nginx/ssl/
-cp /downloads/nginx.key /etc/nginx/ssl/
-site=rutorrent-tls.nginx
+if [ -e /downloads/nginx.key ] && [ -e /downloads/nginx.crt ]; then
+    mkdir -p /etc/nginx/ssl
+    cp /downloads/nginx.crt /etc/nginx/ssl/
+    cp /downloads/nginx.key /etc/nginx/ssl/
+    site=rutorrent-tls.nginx
 fi
 
 cp /root/$site /etc/nginx/sites-enabled/
@@ -30,10 +30,10 @@ cp /root/$site /etc/nginx/sites-enabled/
 
 # Check if .htpasswd presents
 if [ -e /downloads/.htpasswd ]; then
-cp /downloads/.htpasswd /var/www/rutorrent/ && chmod 755 /var/www/rutorrent/.htpasswd && chown www-data:www-data /var/www/rutorrent/.htpasswd
+    cp /downloads/.htpasswd /var/www/rutorrent/ && chmod 755 /var/www/rutorrent/.htpasswd && chown www-data:www-data /var/www/rutorrent/.htpasswd
 else
 # disable basic auth
-sed -i 's/auth_basic/#auth_basic/g' /etc/nginx/sites-enabled/$site
+    sed -i 's/auth_basic/#auth_basic/g' /etc/nginx/sites-enabled/$site
 fi
 
 nginx -g "daemon off;"


### PR DESCRIPTION
doesn't work in 'sh':
if [[ -e /downloads/nginx.key && -e /downloads/nginx.crt ]]; then

Works in sh:
if [ -e /downloads/nginx.key ] && [ -e /downloads/nginx.crt ]; then

Updated indents to make if statements clearer.