### PR TITLE
Move /RPC2 so that it's subject to basic auth too.

### DIFF
--- a/rutorrent-basic.nginx
+++ b/rutorrent-basic.nginx
@@ -5,7 +5,7 @@
 # statements for each of your virtual hosts to this file
 
 ##
-# You should look at the following URL's in order to grasp a solid understanding
+# You should look at the following URL\'s in order to grasp a solid understanding
 # of Nginx configuration files in order to fully unleash the power of Nginx.
 # http://wiki.nginx.org/Pitfalls
 # http://wiki.nginx.org/QuickStart
@@ -26,10 +26,10 @@ server {
 
 	# Make site accessible from http://localhost/
 	server_name localhost;
-	
+
 	# Allow larger .torrent files to upload.
 	# If experiencing a "413 Request Entity Too Large" error,
-	# feel free to increase this setting. 
+	# feel free to increase this setting.
 	client_max_body_size 2M;
 
 	location / {
@@ -38,13 +38,19 @@ server {
 		try_files $uri $uri/ =404;
 		# Uncomment to enable naxsi on this location
 		# include /etc/nginx/naxsi.rules
-                auth_basic "Restricted";
-                auth_basic_user_file /var/www/rutorrent/.htpasswd;
-	}
+		auth_basic "Restricted";
+		auth_basic_user_file /var/www/rutorrent/.htpasswd;
+
+		location /RPC2 {
+			include scgi_params;
+			scgi_pass 127.0.0.1:5000;
+			scgi_param SCRIPT_NAME /RPC2;
+			}
+		}
 
 	# Only for nginx-naxsi used with nginx-naxsi-ui : process denied requests
 	#location /RequestDenied {
-	#	proxy_pass http://127.0.0.1:8080;    
+	#	proxy_pass http://127.0.0.1:8080;
 	#}
 
 	#error_page 404 /404.html;
@@ -61,14 +67,14 @@ server {
 	location ~ \.php$ {
 		fastcgi_split_path_info ^(.+\.php)(/.+)$;
 	# NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
-	
+
 		# With php5-cgi alone:
 	#	fastcgi_pass 127.0.0.1:9000;
 	#	# With php5-fpm:
 		fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
 		fastcgi_index index.php;
 		include fastcgi_params;
-                fastcgi_param SCRIPT_FILENAME $request_filename;
+		fastcgi_param SCRIPT_FILENAME $request_filename;
 	}
 
 	# deny access to .htaccess files, if Apache's document root
@@ -77,12 +83,4 @@ server {
 	#location ~ /\.ht {
 	#	deny all;
 	#}
-
-	location /RPC2 {
-        	include scgi_params;
-	        scgi_pass 127.0.0.1:5000;
-                scgi_param SCRIPT_NAME /RPC2;
-	}
-
 }
-

--- a/rutorrent-tls.nginx
+++ b/rutorrent-tls.nginx
@@ -19,17 +19,17 @@
 
 server {
 	listen 443 ssl;
-  listen [::]:443 default_server ipv6only=on;
+	listen [::]:443 default_server ipv6only=on;
 
-        keepalive_timeout   60;
-        ssl_certificate      /etc/nginx/ssl/nginx.crt;
-        ssl_certificate_key  /etc/nginx/ssl/nginx.key;
-				ssl_ciphers "AES128+EECDH:AES128+EDH";
-				ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
-				ssl_prefer_server_ciphers on;
-				ssl_session_cache shared:SSL:10m;
-				add_header X-Frame-Options SAMEORIGIN;
-				add_header X-Content-Type-Options nosniff;
+	keepalive_timeout   60;
+	ssl_certificate      /etc/nginx/ssl/nginx.crt;
+	ssl_certificate_key  /etc/nginx/ssl/nginx.key;
+	ssl_ciphers "AES128+EECDH:AES128+EDH";
+	ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+	ssl_prefer_server_ciphers on;
+	ssl_session_cache shared:SSL:10m;
+	add_header X-Frame-Options SAMEORIGIN;
+	add_header X-Content-Type-Options nosniff;
 
 	root /var/www/rutorrent;
 	index index.php index.html index.htm;
@@ -43,8 +43,14 @@ server {
 		try_files $uri $uri/ =404;
 		# Uncomment to enable naxsi on this location
 		# include /etc/nginx/naxsi.rules
-                auth_basic "Restricted";
-                auth_basic_user_file /var/www/rutorrent/.htpasswd;
+		auth_basic "Restricted";
+		auth_basic_user_file /var/www/rutorrent/.htpasswd;
+
+		location /RPC2 {
+			include scgi_params;
+			scgi_pass 127.0.0.1:5000;
+			scgi_param SCRIPT_NAME /RPC2;
+		}
 	}
 
 	# Only for nginx-naxsi used with nginx-naxsi-ui : process denied requests
@@ -73,8 +79,8 @@ server {
 		fastcgi_pass unix:/var/run/php/php7.0-fpm.sock;
 		fastcgi_index index.php;
 		include fastcgi_params;
-                fastcgi_param HTTPS on;
-                fastcgi_param SCRIPT_FILENAME $request_filename;
+		fastcgi_param HTTPS on;
+		fastcgi_param SCRIPT_FILENAME $request_filename;
 	}
 
 	# deny access to .htaccess files, if Apache's document root
@@ -83,12 +89,4 @@ server {
 	#location ~ /\.ht {
 	#	deny all;
 	#}
-
-	location /RPC2 {
-        	include scgi_params;
-	        scgi_pass 127.0.0.1:5000;
-                scgi_param SCRIPT_NAME /RPC2;
-	}
-
 }
-


### PR DESCRIPTION
Currently everyone using this config is exposed, anyone can connect and control - and probably execute arbitrary code inside these images.

Also made the syntax more consistent.