### PR TITLE
Update config.php

### DIFF
--- a/config.php
+++ b/config.php
@@ -24,7 +24,7 @@
 	$saveUploadedTorrents = true;		// Save uploaded torrents to profile/torrents directory or not
 	$overwriteUploadedTorrents = false;     // Overwrite existing uploaded torrents in profile/torrents directory or make unique name
 
-	$topDirectory = '/';			// Upper available directory. Absolute path with trail slash.
+	$topDirectory = '/downloads';			// Upper available directory. Absolute path with trail slash.
 	$forbidUserSettings = false;
 
 	$scgi_port = 5000;


### PR DESCRIPTION
Changed $topDirectory to match up with where rutorrent/rtorrent data will actually sit.

This default of root (/) causes issues with plugins which use $topDirectory eg. The HDD freespace plugin, it reports the docker hosts free space, instead of that of where /downloads resides.