### PR TITLE
Add HTTP->HTTPS auto-redirect

### DIFF
--- a/rutorrent-tls.nginx
+++ b/rutorrent-tls.nginx
@@ -36,6 +36,9 @@ server {
 
 	# Make site accessible from http://localhost/
 	server_name localhost;
+	
+	# Automatically redirect HTTP requests on this port to HTTPS
+	error_page 497 https://{$server_name}:{$server_port}/${request_uri}
 
 	location / {
 		# First attempt to serve request as file, then


### PR DESCRIPTION
Sending a HTTP request to the HTTP port should automatically redirect to HTTPS protocol (instead of showing a useless error page). This is the way nginx support that (with a special error code 497 - see http://nginx.org/en/docs/http/ngx_http_ssl_module.html#errors)