### PR TITLE
supervisord.conf: set loglevel to "warn"

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -1,5 +1,6 @@
 [supervisord]
 nodaemon=true
+loglevel=warn
 
 [program:nginx]
 priority=1


### PR DESCRIPTION
to hide `INFO reaped unknown pid` log entries