### PR TITLE
Fixes Unpack/Create plugin

### DIFF
--- a/config.php
+++ b/config.php
@@ -40,10 +40,11 @@
 	$XMLRPCMountPoint = "/RPC2";		// DO NOT DELETE THIS LINE!!! DO NOT COMMENT THIS LINE!!!
 
 	$pathToExternals = array(
-		"php" 	=> '',			// Something like /usr/bin/php. If empty, will be found in PATH.
+		"php" 	=> '/usr/bin/php',			// Something like /usr/bin/php. If empty, will be found in PATH.
+		"pgrep" => '/usr/bin/pgrep',			// Something like /usr/bin/pgrep. If empty, will be found in PATH.
 		"curl"	=> '/usr/bin/curl',	// Something like /usr/bin/curl. If empty, will be found in PATH.
-		"gzip"	=> '',			// Something like /usr/bin/gzip. If empty, will be found in PATH.
-		"id"	=> '',			// Something like /usr/bin/id. If empty, will be found in PATH.
+		"gzip"	=> '/bin/gzip',			// Something like /usr/bin/gzip. If empty, will be found in PATH.
+		"id"	=> '/usr/bin/id',			// Something like /usr/bin/id. If empty, will be found in PATH.
 		"stat"	=> '/usr/bin/stat',	// Something like /usr/bin/stat. If empty, will be found in PATH.
 	);
 


### PR DESCRIPTION
Related: https://github.com/linuxserver/docker-rutorrent/issues/115

Fixes issues like

```
[23.04.2019 20:16:40] _task: Plugin will not work. Webserver user can't access external program (pgrep).
[23.04.2019 20:16:40] create: Plugin will not work. It requires plugin(s) _task
[23.04.2019 20:16:40] unpack: Plugin will not work. It requires plugin(s) _task
[23.04.2019 20:16:40] mediainfo: Plugin will not work. It requires plugin(s) _task
[23.04.2019 20:16:40] screenshots: Plugin will not work. It requires plugin(s) _task
[23.04.2019 20:16:40] spectrogram: Plugin will not work. It requires plugin(s) _task
```

The incomplete array results in the unpack plugin not working anymore as well as the create torrent functionality due to pgrep not being available.

In order to fix "_cloudflare: Plugin will not work. Webserver user can't access external program (python)." python3 would need to be installed, too, and added to the array: "python" => '/usr/bin/python3'