### PR TITLE
Fix SSLeay version for autodl-irssi

### DIFF
--- a/startup-irssi.sh
+++ b/startup-irssi.sh
@@ -52,6 +52,7 @@ then
 	rm autodl-irssi.zip
 	cp autodl-irssi.pl autorun/
 	chown -R rtorrent:rtorrent /home/rtorrent/.irssi
+	sed -i -e 's/1.86/1.84/g' /home/rtorrent/.irssi/scripts/AutodlIrssi/SslSocket.pm
 else
 	echo "Found irssi scripts are installed. Skipping install."
 fi


### PR DESCRIPTION
The current version of autodl-irssi requires `libnet-ssleay-perl >= 1.86`, however, only version 1.84 is available in Ubuntu 18.04.

This fixes `Error: _onReadAvailable ex: Could not read: SSL: Unknown error code: 5` when autodl-irssi is enabled.