### PR TITLE
securing /RPC2 and *.php

### DIFF
--- a/rutorrent-basic.nginx
+++ b/rutorrent-basic.nginx
@@ -69,6 +69,8 @@ server {
 		fastcgi_index index.php;
 		include fastcgi_params;
                 fastcgi_param SCRIPT_FILENAME $request_filename;
+		auth_basic "Restricted";
+		auth_basic_user_file /var/www/rutorrent/.htpasswd;
 	}
 
 	# deny access to .htaccess files, if Apache's document root
@@ -82,6 +84,8 @@ server {
         	include scgi_params;
 	        scgi_pass 127.0.0.1:5000;
                 scgi_param SCRIPT_NAME /RPC2;
+		auth_basic "Restricted";
+		auth_basic_user_file /var/www/rutorrent/.htpasswd;
 	}
 
 }

--- a/rutorrent-tls.nginx
+++ b/rutorrent-tls.nginx
@@ -75,6 +75,8 @@ server {
 		include fastcgi_params;
                 fastcgi_param HTTPS on;
                 fastcgi_param SCRIPT_FILENAME $request_filename;
+		auth_basic "Restricted";
+		auth_basic_user_file /var/www/rutorrent/.htpasswd;
 	}
 
 	# deny access to .htaccess files, if Apache's document root
@@ -88,6 +90,8 @@ server {
         	include scgi_params;
 	        scgi_pass 127.0.0.1:5000;
                 scgi_param SCRIPT_NAME /RPC2;
+		auth_basic "Restricted";
+		auth_basic_user_file /var/www/rutorrent/.htpasswd;
 	}
 
 }


### PR DESCRIPTION
The "/RPC2" and ".php" parts of the nginx config are missing the password protection.
This means one can easily circumvent the password and control the server.
The easiest way to reproduce this is using something like transdroid and just connect directly the
`http(s)://server:port/RPC2` with no username and password. This will give you full control of rtorrent, skipping rutorrent completely.